### PR TITLE
Improve readability

### DIFF
--- a/sr_description/hand/xacro/backward_compat.urdf.xacro
+++ b/sr_description/hand/xacro/backward_compat.urdf.xacro
@@ -1,8 +1,8 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:property name="lf" default="${None}" />
   <xacro:property name="extra_lite" default="${None}" />
-  <xacro:if value="${[p for p in [muscle, muscletrans, extra_lite, lf, bio, bt_sp, eli] if p is not None]}">
-    ${xacro.warning('Deprecated use of shadowhand macro: \nReplace parameters muscle, muscletrans, lf, extra_lite with hand_type and fingers\nand parameters bio, bt_sp, eli with [tip|mid|prox|palm]_sensors.')}
+  <xacro:if value="${[p for p in [extra_lite, lf, bio, bt_sp, eli] if p is not None]}">
+    ${xacro.warning('Deprecated use of shadowhand macro: \nReplace parameters lf, extra_lite with fingers\nand parameters bio, bt_sp, eli with [tip|mid|prox|palm]_sensors.')}
   </xacro:if>
 
   <!-- for backward compatibility define new params from old ones -->
@@ -23,15 +23,6 @@
     <xacro:property name="prox_sensors" value="${['std', 'std', 'std', 'std', 'std']}" />
     <xacro:property name="mid_sensors" value="${['std', 'std', 'std', 'std', 'std']}" />
     <xacro:property name="tip_sensors" value="${['eli', 'eli', 'eli', 'eli', 'eli']}" />
-  </xacro:if>
-
-  <xacro:if value="${muscle}">
-    <xacro:if value="${muscletrans}">
-      <xacro:property name="hand_type" value="hand_mt" />
-    </xacro:if>
-    <xacro:unless value="${muscletrans}">
-      <xacro:property name="hand_type" value="hand_m" />
-    </xacro:unless>
   </xacro:if>
 
   <xacro:if value="${lf is None}">

--- a/sr_description/hand/xacro/backward_compat.urdf.xacro
+++ b/sr_description/hand/xacro/backward_compat.urdf.xacro
@@ -1,8 +1,6 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:property name="lf" default="${None}" />
-  <xacro:property name="extra_lite" default="${None}" />
-  <xacro:if value="${[p for p in [extra_lite, lf, bio, bt_sp, eli] if p is not None]}">
-    ${xacro.warning('Deprecated use of shadowhand macro: \nReplace parameters lf, extra_lite with fingers\nand parameters bio, bt_sp, eli with [tip|mid|prox|palm]_sensors.')}
+  <xacro:if value="${[p for p in [bio, bt_sp, eli] if p is not None]}">
+    ${xacro.warning('Deprecated use of shadowhand macro: Replace parameters bio, bt_sp, eli with [tip|mid|prox|palm]_sensors.')}
   </xacro:if>
 
   <!-- for backward compatibility define new params from old ones -->
@@ -24,9 +22,4 @@
     <xacro:property name="mid_sensors" value="${['std', 'std', 'std', 'std', 'std']}" />
     <xacro:property name="tip_sensors" value="${['eli', 'eli', 'eli', 'eli', 'eli']}" />
   </xacro:if>
-
-  <xacro:if value="${lf is None}">
-    <xacro:property name="lf" value="True" />
-  </xacro:if>
-
 </robot>

--- a/sr_description/hand/xacro/ff_biotac_hand.urdf.xacro
+++ b/sr_description/hand/xacro/ff_biotac_hand.urdf.xacro
@@ -16,7 +16,7 @@
     <!-- forward to generic macro -->
     <xacro:include filename="$(find sr_description)/hand/xacro/full_hand.urdf.xacro" />
     <!-- Enforce BioTac on First Finger -->
-    <xacro:shadowhand fingers="${5 * [1]}" reflect="${reflect}" prefix="${prefix}"
+    <xacro:shadowhand fingers="all" reflect="${reflect}" prefix="${prefix}"
     tip_sensors="${[tip_sensors[0]] + ['bio'] + tip_sensors[2:]}"/>
   </xacro:macro>
 </robot>

--- a/sr_description/hand/xacro/finger/distal/distal.transmission.xacro
+++ b/sr_description/hand/xacro/finger/distal/distal.transmission.xacro
@@ -10,7 +10,7 @@
   <xacro:macro name="distal_transmission" params="hand_type:=^ prefix:=^ joint_prefix:=^ link_prefix:=^" >
 
    <!-- muscle hand -->
-    <xacro:if value="${hand_type == 'hand_mt'}">
+    <xacro:if value="${hand_type == 'muscletrans'}">
         <transmission name="${prefix}${link_prefix}distal_transmission">
             <type>sr_mechanism_model/SimpleTransmissionForMuscle</type>
             <actuator name="${prefix}${joint_prefix}J1">
@@ -23,7 +23,7 @@
         </transmission>
     </xacro:if>
     <!-- motor hand -->
-    <xacro:unless value="${hand_type == 'hand_mt'}">
+    <xacro:unless value="${hand_type == 'muscletrans'}">
         <transmission name="${prefix}${link_prefix}distal_transmission">
             <type>sr_mechanism_model/SimpleTransmission</type>
             <actuator name="${prefix}${joint_prefix}J1">

--- a/sr_description/hand/xacro/finger/knuckle/knuckle.transmission.xacro
+++ b/sr_description/hand/xacro/finger/knuckle/knuckle.transmission.xacro
@@ -10,7 +10,7 @@
     <xacro:macro name="knuckle_transmission" params="hand_type:=^ prefix:=^ joint_prefix:=^ link_prefix:=^">
 
         <!-- muscle hand -->
-        <xacro:if value="${hand_type == 'hand_mt'}">
+        <xacro:if value="${hand_type == 'muscletrans'}">
             <transmission name="${prefix}${link_prefix}knuckle_transmission">
                 <type>sr_mechanism_model/SimpleTransmissionForMuscle</type>
                 <actuator name="${prefix}${joint_prefix}J4">
@@ -23,7 +23,7 @@
             </transmission>
         </xacro:if>
         <!-- motor hand -->
-        <xacro:unless value="${hand_type == 'hand_mt'}">
+        <xacro:unless value="${hand_type == 'muscletrans'}">
             <transmission name="${prefix}${link_prefix}knuckle_transmission">
                 <type>sr_mechanism_model/SimpleTransmission</type>
                 <actuator name="${prefix}${joint_prefix}J4">

--- a/sr_description/hand/xacro/finger/lfmetacarpal/lfmetacarpal.transmission.xacro
+++ b/sr_description/hand/xacro/finger/lfmetacarpal/lfmetacarpal.transmission.xacro
@@ -8,7 +8,7 @@
     <xacro:macro name="lfmetacarpal_transmission" params="hand_type:=^ prefix:=^">
 
         <!-- muscle hand -->
-        <xacro:if value="${hand_type == 'hand_mt'}">
+        <xacro:if value="${hand_type == 'muscletrans'}">
             <transmission name="${prefix}lfmetacarpal_transmission">
                 <type>sr_mechanism_model/SimpleTransmissionForMuscle</type>
                 <actuator name="${prefix}LFJ5">
@@ -21,7 +21,7 @@
             </transmission>
         </xacro:if>
         <!-- motor hand -->
-        <xacro:unless value="${hand_type == 'hand_mt'}">
+        <xacro:unless value="${hand_type == 'muscletrans'}">
             <transmission name="${prefix}lfmetacarpal_transmission">
                 <type>sr_mechanism_model/SimpleTransmission</type>
                 <actuator name="${prefix}LFJ5">

--- a/sr_description/hand/xacro/finger/middle/middle.transmission.xacro
+++ b/sr_description/hand/xacro/finger/middle/middle.transmission.xacro
@@ -10,7 +10,7 @@
     <xacro:macro name="middle_transmission" params="hand_type:=^ prefix:=^ joint_prefix:=^ link_prefix:=^">
 
         <!-- muscle hand -->
-        <xacro:if value="${hand_type == 'hand_mt'}">
+        <xacro:if value="${hand_type == 'muscletrans'}">
             <transmission name="${prefix}${link_prefix}middle_transmission">
                 <type>sr_mechanism_model/J0TransmissionForMuscle</type>
                 <actuator name="${prefix}${joint_prefix}J0">
@@ -28,7 +28,7 @@
             </transmission>
         </xacro:if>
         <!-- motor hand -->
-        <xacro:unless value="${hand_type == 'hand_mt'}">
+        <xacro:unless value="${hand_type == 'muscletrans'}">
             <transmission name="${prefix}${link_prefix}middle_transmission">
                 <type>sr_mechanism_model/J0Transmission</type>
                 <actuator name="${prefix}${joint_prefix}J0">

--- a/sr_description/hand/xacro/finger/proximal/proximal.transmission.xacro
+++ b/sr_description/hand/xacro/finger/proximal/proximal.transmission.xacro
@@ -10,7 +10,7 @@
     <xacro:macro name="proximal_transmission" params="hand_type:=^ prefix:=^ joint_prefix:=^ link_prefix:=^">
 
         <!-- muscle hand -->
-        <xacro:if value="${hand_type == 'hand_mt'}">
+        <xacro:if value="${hand_type == 'muscletrans'}">
             <transmission name="${prefix}${link_prefix}proximal_transmission">
                 <type>sr_mechanism_model/SimpleTransmissionForMuscle</type>
                 <actuator name="${prefix}${joint_prefix}J3">
@@ -23,7 +23,7 @@
             </transmission>
         </xacro:if>
         <!-- motor hand -->
-        <xacro:unless value="${hand_type == 'hand_mt'}">
+        <xacro:unless value="${hand_type == 'muscletrans'}">
             <transmission name="${prefix}${link_prefix}proximal_transmission">
                 <type>sr_mechanism_model/SimpleTransmission</type>
                 <actuator name="${prefix}${joint_prefix}J3">

--- a/sr_description/hand/xacro/forearm/forearm.urdf.xacro
+++ b/sr_description/hand/xacro/forearm/forearm.urdf.xacro
@@ -1,5 +1,5 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <!-- hand_type can be either hand_e (default), hand_m, hand_e_plus -->
+  <!-- hand_type can be either motor (default), muscle, motor+ -->
   <!-- prefix can be anything but usually is "r_" or  "l_" for right and left hands distinction -->
   <!-- cable_mesh is set to true when cable collision should be taken into account -->
   <xacro:macro name="dark_grey" >
@@ -20,7 +20,7 @@
         <inertia ixx="0.0138" ixy="0.0" ixz="0.0" iyy="0.0138"
         iyz="0.0" izz="0.00744" />
       </inertial>
-      <xacro:if value="${hand_type.startswith('hand_m')}">
+      <xacro:if value="${hand_type.startswith('muscle')}">
         <visual>
           <origin xyz="0 0 0" rpy="0 0 0" />
           <geometry name="${prefix}forearm_visual">
@@ -29,8 +29,8 @@
           <material name="Grey" />
         </visual>
       </xacro:if>
-      <xacro:unless value="${hand_type.startswith('hand_m')}">
-        <xacro:if value="${hand_type == 'hand_e'}">
+      <xacro:unless value="${hand_type.startswith('muscle')}">
+        <xacro:if value="${hand_type == 'motor'}">
           <visual>
             <origin xyz="0 0 0" rpy="0 0 0" />
             <geometry name="${prefix}forearm_visual">
@@ -39,7 +39,7 @@
             <material name="Grey" />
           </visual>
         </xacro:if>
-        <xacro:if value="${hand_type == 'hand_e_plus'}">
+        <xacro:if value="${hand_type == 'motor+'}">
           <visual>
             <origin xyz="0 0 0" rpy="0 0 0" />
             <geometry name="${prefix}forearm_visual">
@@ -50,22 +50,22 @@
         </xacro:if>
       </xacro:unless>
       <collision>
-        <xacro:if value="${hand_type.startswith('hand_m')}">
+        <xacro:if value="${hand_type.startswith('muscle')}">
           <origin xyz="0 0 0.185" rpy="0 0 0" />
           <geometry name="${prefix}forearm_collision">
             <cylinder radius="0.075" length="0.37" />
           </geometry>
           <xacro:dark_grey/>
         </xacro:if>
-        <xacro:unless value="${hand_type.startswith('hand_m')}">
-          <xacro:if value="${hand_type == 'hand_e'}">
+        <xacro:unless value="${hand_type.startswith('muscle')}">
+          <xacro:if value="${hand_type == 'motor'}">
             <origin xyz="0 0 0.092" rpy="0 0 0" />
             <geometry name="${prefix}forearm_collision">
               <cylinder radius="0.07" length="0.184"/>
             </geometry>
             <xacro:dark_grey/>
           </xacro:if>
-          <xacro:if value="${hand_type == 'hand_e_plus'}">
+          <xacro:if value="${hand_type == 'motor+'}">
             <origin xyz="0 0 0" rpy="0 0 0" />
             <geometry name="${prefix}forearm_collision">
               <mesh filename="package://sr_description/meshes/hand/forearm_collision_plus.stl" scale="0.001 0.001 0.001" />
@@ -76,13 +76,13 @@
       </collision>
       <!-- wrist mount -->
       <collision>
-        <xacro:if value="${hand_type.startswith('hand_m')}">
+        <xacro:if value="${hand_type.startswith('muscle')}">
           <origin xyz="0 0 0.395" rpy="0 0 0" />
           <geometry>
             <box size="0.03 0.04 0.06" />
           </geometry>
         </xacro:if>
-        <xacro:unless value="${hand_type.startswith('hand_m')}">
+        <xacro:unless value="${hand_type.startswith('muscle')}">
           <origin xyz="0 -0.01 0.181" rpy="0 0.78 0" />
           <geometry>
             <box size="0.07 0.07 0.07" />

--- a/sr_description/hand/xacro/forearm/forearm_lite.urdf.xacro
+++ b/sr_description/hand/xacro/forearm/forearm_lite.urdf.xacro
@@ -14,11 +14,11 @@
       <visual>
         <origin xyz="0 0 0" rpy="0 0 ${pi/2}" />
         <geometry name="${prefix}forearm_visual">
-          <xacro:if value="${hand_type == 'hand_m'}">
+          <xacro:if value="${hand_type == 'muscle'}">
             <mesh filename="package://sr_description/meshes/hand/forearm_lite.dae"
             scale="1.0 1.0 1.0" />
           </xacro:if>
-          <xacro:unless value="${hand_type == 'hand_m'}">
+          <xacro:unless value="${hand_type == 'muscle'}">
             <mesh filename="package://sr_description/meshes/hand/forearm_lite.dae"
             scale="1.0 1.0 1.0" />
           </xacro:unless>
@@ -26,13 +26,13 @@
         <material name="Grey" />
       </visual>
       <collision>
-        <xacro:if value="${hand_type == 'hand_m'}">
+        <xacro:if value="${hand_type == 'muscle'}">
           <origin xyz="0 0 0.185" rpy="0 0 0" />
           <geometry name="${prefix}forearm_collision">
             <cylinder radius="0.075" length="0.37" />
           </geometry>
         </xacro:if>
-        <xacro:unless value="${hand_type == 'hand_m'}">
+        <xacro:unless value="${hand_type == 'muscle'}">
           <origin xyz="0 0 0.065" rpy="0 0 0" />
           <geometry name="${prefix}forearm_collision">
             <box size="0.120 0.109 0.130" />

--- a/sr_description/hand/xacro/full_hand.urdf.xacro
+++ b/sr_description/hand/xacro/full_hand.urdf.xacro
@@ -5,7 +5,7 @@
   <xacro:include filename="$(find sr_description)/hand/xacro/finger/fingers.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/hand/xacro/thumb/thumb.urdf.xacro" />
   <!-- hand_type can be: motor, motor+, muscle (muscle), muscletrans (muscletrans) -->
-  <!-- fingers: dict specifying available fingers, default: dict(th=1, ff=1, mf=1, rf=1, lf=1) -->
+  <!-- fingers: list-like string specifying available fingers, default: 'th ff mf rf lf' -->
   <!-- tip_sensors: dict specifying the fingertip (tactile) sensors per finger: std, none, bio, bt_sp, eli -->
   <!-- mid_sensors: dict specifying the middle-phalange (tactile) sensors per finger: std, none, bio -->
   <!-- prox_sensors: dict specifying the proximal (tactile) sensors per finger: std, none -->
@@ -18,11 +18,15 @@
   <!-- bt_sp (deprecated) is true for BT_SP finger or false for standard finger -->
   <!-- eli (deprecated) is true for ellipsoid fingertip or false for standard finger -->
   <!-- lf (deprecated) is true if we want a little finger, false otherwise -->
-  <xacro:macro name="shadowhand" params="hand_type:='motor' reflect prefix cable_mesh:=False fingers:=${[1,1,1,1,1]}
+  <xacro:macro name="shadowhand" params="hand_type:='motor' reflect prefix cable_mesh:=False fingers:=all
           tip_sensors:=${5 * ['std']} mid_sensors:=${5 * ['std']} prox_sensors:=${5 * ['std']} palm_sensor:=std
           muscletrans:=^|${None} muscle:=^|${None} lf:=^|${None} bio:=^|${None} bt_sp:=^|${None} eli:=^|${None}">
     <!-- Unify hand type parameter, also handling deprecated muscletrans, muscle -->
     <xacro:include filename="$(find sr_description)/hand/xacro/process_hand_type_parameter.xacro" />
+    <!-- Process fingers parameter, also handling deprecated lf -->
+    <xacro:property name="_all_finger_tokens_" value="${python.set('th ff mf rf lf'.split())}" />
+    <xacro:include filename="$(find sr_description)/hand/xacro/process_fingers_parameter.xacro" />
+    <!-- handle deprecated parameters -->
     <xacro:include filename="$(find sr_description)/hand/xacro/backward_compat.urdf.xacro" />
     <!-- Forearm -->
     <xacro:forearm />
@@ -40,35 +44,35 @@
     <!-- Palm -->
     <xacro:palm parent="${prefix}wrist" />
     <!-- First Finger -->
-    <xacro:if value="${fingers[1] == 1}">
+    <xacro:if value="${'ff' in fingers}">
       <xacro:finger link_prefix="ff" joint_prefix="FF" tip_sensor="${tip_sensors[1]}" prox_sensor="${prox_sensors[1]}" mid_sensor="${mid_sensors[1]}" parent="${prefix}palm">
         <origin xyz="${reflect*0.033} 0 0.095" rpy="0 0 0" />
         <axis xyz="0 ${-1*reflect} 0" />
       </xacro:finger>
     </xacro:if>
     <!-- Middle Finger -->
-    <xacro:if value="${fingers[2] == 1}">
+    <xacro:if value="${'mf' in fingers}">
       <xacro:finger link_prefix="mf" joint_prefix="MF" tip_sensor="${tip_sensors[2]}" prox_sensor="${prox_sensors[2]}" mid_sensor="${mid_sensors[2]}" parent="${prefix}palm">
         <origin xyz="${reflect*0.011} 0 0.099" rpy="0 0 0" />
         <axis xyz="0 ${-1*reflect} 0" />
       </xacro:finger>
     </xacro:if>
     <!-- Ring Finger -->
-    <xacro:if value="${fingers[3] == 1}">
+    <xacro:if value="${'rf' in fingers}">
       <xacro:finger link_prefix="rf" joint_prefix="RF" tip_sensor="${tip_sensors[3]}" prox_sensor="${prox_sensors[3]}" mid_sensor="${mid_sensors[3]}" parent="${prefix}palm">
         <origin xyz="${reflect*-0.011} 0 0.095" rpy="0 0 0" />
         <axis xyz="0 ${reflect} 0" />
       </xacro:finger>
     </xacro:if>
     <!-- Little Finger  -->
-    <xacro:if value="${fingers[4] == 1 and lf}">
+    <xacro:if value="${'lf' in fingers}">
       <xacro:finger link_prefix="lf" joint_prefix="LF" tip_sensor="${tip_sensors[4]}" prox_sensor="${prox_sensors[4]}" mid_sensor="${mid_sensors[4]}" parent="${prefix}palm">
         <origin xyz="0 0 0.06579" rpy="0 0 0" />
         <axis xyz="0 ${reflect} 0" />
       </xacro:finger>
     </xacro:if>
     <!-- Thumb  -->
-    <xacro:if value="${fingers[0] == 1}">
+    <xacro:if value="${'th' in fingers}">
       <xacro:thumb is_lite="0" parent="${prefix}palm" tip_sensor="${tip_sensors[0]}" prox_sensor="${prox_sensors[0]}" mid_sensor="${mid_sensors[0]}" />
     </xacro:if>
 

--- a/sr_description/hand/xacro/full_hand.urdf.xacro
+++ b/sr_description/hand/xacro/full_hand.urdf.xacro
@@ -4,7 +4,7 @@
   <xacro:include filename="$(find sr_description)/hand/xacro/palm/palm.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/hand/xacro/finger/fingers.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/hand/xacro/thumb/thumb.urdf.xacro" />
-  <!-- hand_type can be: hand_e, hand_e_plus, hand_m (muscle), hand_mt (muscletrans) -->
+  <!-- hand_type can be: motor, motor+, muscle (muscle), muscletrans (muscletrans) -->
   <!-- fingers: dict specifying available fingers, default: dict(th=1, ff=1, mf=1, rf=1, lf=1) -->
   <!-- tip_sensors: dict specifying the fingertip (tactile) sensors per finger: std, none, bio, bt_sp, eli -->
   <!-- mid_sensors: dict specifying the middle-phalange (tactile) sensors per finger: std, none, bio -->
@@ -18,20 +18,21 @@
   <!-- bt_sp (deprecated) is true for BT_SP finger or false for standard finger -->
   <!-- eli (deprecated) is true for ellipsoid fingertip or false for standard finger -->
   <!-- lf (deprecated) is true if we want a little finger, false otherwise -->
-  <xacro:macro name="shadowhand" params="hand_type:='hand_e' reflect prefix cable_mesh:=False fingers:=${[1,1,1,1,1]}
+  <xacro:macro name="shadowhand" params="hand_type:='motor' reflect prefix cable_mesh:=False fingers:=${[1,1,1,1,1]}
           tip_sensors:=${5 * ['std']} mid_sensors:=${5 * ['std']} prox_sensors:=${5 * ['std']} palm_sensor:=std
           muscletrans:=^|${None} muscle:=^|${None} lf:=^|${None} bio:=^|${None} bt_sp:=^|${None} eli:=^|${None}">
-    <!-- handle deprecated parameters -->
+    <!-- Unify hand type parameter, also handling deprecated muscletrans, muscle -->
+    <xacro:include filename="$(find sr_description)/hand/xacro/process_hand_type_parameter.xacro" />
     <xacro:include filename="$(find sr_description)/hand/xacro/backward_compat.urdf.xacro" />
     <!-- Forearm -->
     <xacro:forearm />
     <!-- Wrist -->
-    <xacro:if value="${hand_type.startswith('hand_m')}">
+    <xacro:if value="${hand_type.startswith('muscle')}">
       <xacro:wrist parent="${prefix}forearm">
         <origin xyz="0 0 0.4096" rpy="0 0 0" />
       </xacro:wrist>
     </xacro:if>
-    <xacro:unless value="${hand_type.startswith('hand_m')}">
+    <xacro:unless value="${hand_type.startswith('muscle')}">
       <xacro:wrist parent="${prefix}forearm">
         <origin xyz="0 -0.010 0.213" rpy="0 0 0" />
       </xacro:wrist>

--- a/sr_description/hand/xacro/hand_E_no_mf_rf.urdf.xacro
+++ b/sr_description/hand/xacro/hand_E_no_mf_rf.urdf.xacro
@@ -12,6 +12,6 @@
     ${xacro.warning("Use full_hand.urdf.xacro instead with fingers='th ff lf'")}
     <!-- forward to generic macro -->
     <xacro:include filename="$(find sr_description)/hand/xacro/full_hand.urdf.xacro" />
-    <xacro:shadowhand fingers="${[1, 1, 0, 0, 1 if lf else 0]}" reflect="${reflect}" prefix="${prefix}" />
+    <xacro:shadowhand fingers="th ff ${'lf' if lf else ''}" reflect="${reflect}" prefix="${prefix}" />
   </xacro:macro>
 </robot>

--- a/sr_description/hand/xacro/hand_lite.urdf.xacro
+++ b/sr_description/hand/xacro/hand_lite.urdf.xacro
@@ -8,7 +8,7 @@ xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:include filename="$(find sr_description)/hand/xacro/finger/fingers.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/hand/xacro/thumb/thumb.urdf.xacro" />
 
-  <!-- hand_type can be: hand_e, hand_e_plus, hand_m (muscle), hand_mt (muscletrans) -->
+  <!-- hand_type can be: motor, motor+, muscle (muscle), muscletrans (muscletrans) -->
   <!-- fingers: dict specifying available fingers, default: dict(th=1, ff=1, mf=1, rf=1, lf=1) -->
   <!-- tip_sensors: dict specifying the fingertip (tactile) sensors per finger: std, none, bio, bt_sp, eli -->
   <!-- mid_sensors: dict specifying the middle-phalange (tactile) sensors per finger: std, none, bio -->
@@ -22,10 +22,11 @@ xmlns:xacro="http://www.ros.org/wiki/xacro">
   <!-- bio (deprecated) is true for biotac finger or false for standard finger -->
   <!-- bt_sp (deprecated) is true for BT_SP finger or false for standard finger -->
   <!-- eli (deprecated) is true for ellipsoid fingertip or false for standard finger -->
-  <xacro:macro name="shadowhand" params="hand_type:='hand_e' reflect prefix cable_mesh:=False fingers:=${[1,1,1,1]}
+  <xacro:macro name="shadowhand" params="hand_type:='motor' reflect prefix cable_mesh:=False fingers:=${[1,1,1,1]}
           tip_sensors:=${4 * ['std']} mid_sensors:=${4 * ['std']} prox_sensors:=${4 * ['std']} palm_sensor:=std
           extra_lite:=^|${None} muscletrans:=^|${None} muscle:=^|${None} bio:=^|${None} bt_sp:=^|${None} eli:=^|${None}">
-    <!-- handle deprecated parameters -->
+    <!-- Unify hand type parameter, also handling deprecated muscletrans, muscle -->
+    <xacro:include filename="$(find sr_description)/hand/xacro/process_hand_type_parameter.xacro" />
     <xacro:include filename="$(find sr_description)/hand/xacro/backward_compat.urdf.xacro" />
 
     <xacro:if value="${extra_lite}">

--- a/sr_description/hand/xacro/hand_lite.urdf.xacro
+++ b/sr_description/hand/xacro/hand_lite.urdf.xacro
@@ -9,7 +9,7 @@ xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:include filename="$(find sr_description)/hand/xacro/thumb/thumb.urdf.xacro" />
 
   <!-- hand_type can be: motor, motor+, muscle (muscle), muscletrans (muscletrans) -->
-  <!-- fingers: dict specifying available fingers, default: dict(th=1, ff=1, mf=1, rf=1, lf=1) -->
+  <!-- fingers: list-like string specifying available fingers, default: 'th ff mf rf' -->
   <!-- tip_sensors: dict specifying the fingertip (tactile) sensors per finger: std, none, bio, bt_sp, eli -->
   <!-- mid_sensors: dict specifying the middle-phalange (tactile) sensors per finger: std, none, bio -->
   <!-- prox_sensors: dict specifying the proximal (tactile) sensors per finger: std, none -->
@@ -22,16 +22,16 @@ xmlns:xacro="http://www.ros.org/wiki/xacro">
   <!-- bio (deprecated) is true for biotac finger or false for standard finger -->
   <!-- bt_sp (deprecated) is true for BT_SP finger or false for standard finger -->
   <!-- eli (deprecated) is true for ellipsoid fingertip or false for standard finger -->
-  <xacro:macro name="shadowhand" params="hand_type:='motor' reflect prefix cable_mesh:=False fingers:=${[1,1,1,1]}
+  <xacro:macro name="shadowhand" params="hand_type:='motor' reflect prefix cable_mesh:=False fingers:=all
           tip_sensors:=${4 * ['std']} mid_sensors:=${4 * ['std']} prox_sensors:=${4 * ['std']} palm_sensor:=std
           extra_lite:=^|${None} muscletrans:=^|${None} muscle:=^|${None} bio:=^|${None} bt_sp:=^|${None} eli:=^|${None}">
     <!-- Unify hand type parameter, also handling deprecated muscletrans, muscle -->
     <xacro:include filename="$(find sr_description)/hand/xacro/process_hand_type_parameter.xacro" />
+    <!-- Process fingers parameter, also handling deprecated extra_lite -->
+    <xacro:property name="_all_finger_tokens_" value="${python.set('th ff mf rf'.split())}" />
+    <xacro:include filename="$(find sr_description)/hand/xacro/process_fingers_parameter.xacro" />
+    <!-- handle deprecated parameters -->
     <xacro:include filename="$(find sr_description)/hand/xacro/backward_compat.urdf.xacro" />
-
-    <xacro:if value="${extra_lite}">
-      <xacro:property name="fingers" value="${[1,1,0,1]}" />
-    </xacro:if>
 
     <!-- Forearm -->
     <xacro:forearm />
@@ -46,7 +46,7 @@ xmlns:xacro="http://www.ros.org/wiki/xacro">
     <!-- Palm -->
     <xacro:palm parent="${prefix}wrist" />
     <!-- First Finger -->
-    <xacro:if value="${fingers[1] == 1}">
+    <xacro:if value="${'ff' in fingers}">
       <xacro:finger link_prefix="ff" joint_prefix="FF" tip_sensor="${tip_sensors[1]}"
                     prox_sensor="${prox_sensors[1]}" mid_sensor="${mid_sensors[1]}"
                     parent="${prefix}palm">
@@ -55,7 +55,7 @@ xmlns:xacro="http://www.ros.org/wiki/xacro">
       </xacro:finger>
     </xacro:if>
     <!-- Middle Finger -->
-    <xacro:if value="${fingers[2] == 1}">
+    <xacro:if value="${'mf' in fingers}">
       <xacro:finger link_prefix="mf" joint_prefix="MF" tip_sensor="${tip_sensors[2]}"
                     prox_sensor="${prox_sensors[2]}" mid_sensor="${mid_sensors[2]}"
                     parent="${prefix}palm">
@@ -64,7 +64,7 @@ xmlns:xacro="http://www.ros.org/wiki/xacro">
       </xacro:finger>
     </xacro:if>
     <!-- Ring Finger -->
-    <xacro:if value="${fingers[3] == 1}">
+    <xacro:if value="${'rf' in fingers}">
       <xacro:finger link_prefix="rf" joint_prefix="RF" tip_sensor="${tip_sensors[3]}"
                     prox_sensor="${prox_sensors[3]}" mid_sensor="${mid_sensors[3]}"
                     parent="${prefix}palm">
@@ -74,7 +74,7 @@ xmlns:xacro="http://www.ros.org/wiki/xacro">
     </xacro:if>
     <!-- No Little Finger on Lite hand -->
     <!-- Thumb  -->
-    <xacro:if value="${fingers[0] == 1}">
+    <xacro:if value="${'th' in fingers}">
       <xacro:thumb is_lite="1" parent="${prefix}palm" tip_sensor="${tip_sensors[0]}"
                    prox_sensor="${prox_sensors[0]}" mid_sensor="${mid_sensors[0]}" />
     </xacro:if>

--- a/sr_description/hand/xacro/one_finger_unit.urdf.xacro
+++ b/sr_description/hand/xacro/one_finger_unit.urdf.xacro
@@ -20,6 +20,8 @@ xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:macro name="shadowhand" params="hand_type:='motor' reflect prefix cable_mesh:=False
           tip_sensor:=std mid_sensor:=std prox_sensor:=std palm_sensor:=std
           muscletrans:=${None} muscle:=${None} bio:=${None} bt_sp:=${None} eli:=${None}">
+    <!-- Unify hand type parameter, also handling deprecated muscletrans, muscle -->
+    <xacro:include filename="$(find sr_description)/hand/xacro/process_hand_type_parameter.xacro" />
     <xacro:property name="tip_sensors" value="${5 * [tip_sensor]}" />
     <xacro:property name="mid_sensors" value="${5 * [mid_sensor]}" />
     <xacro:property name="prox_sensors" value="${5 * [prox_sensor]}" />

--- a/sr_description/hand/xacro/one_finger_unit.urdf.xacro
+++ b/sr_description/hand/xacro/one_finger_unit.urdf.xacro
@@ -4,7 +4,7 @@ xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
 xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:include filename="$(find sr_description)/hand/xacro/forearm/forearm.urdf.xacro" />
   <xacro:include filename="$(find sr_description)/hand/xacro/finger/fingers.urdf.xacro" />
-  <!-- hand_type describes the hand type, hand_e, hand_e_plus, hand_m (muscle) -->
+  <!-- hand_type describes the hand type, motor, motor+, muscle (muscle) -->
   <!-- muscletrans (deprecated) is true for muscle transmission to be used, false to use motor transmission -->
   <!-- muscle (deprecated) is true for muscle hand or false for motor hand -->
   <!-- muscle is true for muscle hand or false for motor hand -->
@@ -17,7 +17,7 @@ xmlns:xacro="http://www.ros.org/wiki/xacro">
   <!-- palm_sensor describes the sensor none, bumper -->
   <!-- reflect is either 1 (for right hand) or -1 (for left hand) -->
   <!-- prefix can be anything but usually is "r_" or  "l_" for right and left hands distinction -->
-  <xacro:macro name="shadowhand" params="hand_type:='hand_e' reflect prefix cable_mesh:=False
+  <xacro:macro name="shadowhand" params="hand_type:='motor' reflect prefix cable_mesh:=False
           tip_sensor:=std mid_sensor:=std prox_sensor:=std palm_sensor:=std
           muscletrans:=${None} muscle:=${None} bio:=${None} bt_sp:=${None} eli:=${None}">
     <xacro:property name="tip_sensors" value="${5 * [tip_sensor]}" />

--- a/sr_description/hand/xacro/palm/palm.transmission.xacro
+++ b/sr_description/hand/xacro/palm/palm.transmission.xacro
@@ -8,7 +8,7 @@
     <xacro:macro name="shadowhand_palm_transmission" params="hand_type:=^ prefix:=^">
 
         <!-- muscle hand -->
-        <xacro:if value="${hand_type == 'hand_mt'}">
+        <xacro:if value="${hand_type == 'muscletrans'}">
             <transmission name="${prefix}palm_transmission">
                 <type>sr_mechanism_model/SimpleTransmissionForMuscle</type>
                 <actuator name="${prefix}WRJ1">
@@ -21,7 +21,7 @@
             </transmission>
         </xacro:if>
         <!-- motor hand -->
-        <xacro:unless value="${hand_type == 'hand_mt'}">
+        <xacro:unless value="${hand_type == 'muscletrans'}">
             <transmission name="${prefix}palm_transmission">
                 <type>sr_mechanism_model/SimpleTransmission</type>
                 <actuator name="${prefix}WRJ1">

--- a/sr_description/hand/xacro/process_fingers_parameter.xacro
+++ b/sr_description/hand/xacro/process_fingers_parameter.xacro
@@ -7,7 +7,7 @@
 		<xacro:property name="fingers" value="${xacro.tokenize(fingers)}" lazy_eval="false" />
 	</xacro:unless>
 	<!-- Normalize finger tokens to lower case -->
-	<xacro:property name="fingers" value="${list(map(str.lower, fingers))}" lazy_eval="false" />
+	<xacro:property name="fingers" value="${[f.lower() for f in fingers]}" lazy_eval="false" />
 	<!-- Validate for invalid finger tokens -->
 	<xacro:property name="_unknown_finger_tokens_" value="${python.set(fingers) - _all_finger_tokens_}" />
 	<xacro:if value="${_unknown_finger_tokens_}">${xacro.error('Unknown finger specifiers: ' + ', '.join(_unknown_finger_tokens_))}</xacro:if>

--- a/sr_description/hand/xacro/process_fingers_parameter.xacro
+++ b/sr_description/hand/xacro/process_fingers_parameter.xacro
@@ -1,0 +1,32 @@
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+	<xacro:if value="${fingers.lower() == 'all'}">
+		<xacro:property name="fingers" value="${list(_all_finger_tokens_)}" />
+	</xacro:if>
+	<xacro:unless value="${python.isinstance(fingers, list)}">
+		<!-- Transform string parameter into a list -->
+		<xacro:property name="fingers" value="${xacro.tokenize(fingers)}" lazy_eval="false" />
+	</xacro:unless>
+	<!-- Normalize finger tokens to lower case -->
+	<xacro:property name="fingers" value="${list(map(str.lower, fingers))}" lazy_eval="false" />
+	<!-- Validate for invalid finger tokens -->
+	<xacro:property name="_unknown_finger_tokens_" value="${python.set(fingers) - _all_finger_tokens_}" />
+	<xacro:if value="${_unknown_finger_tokens_}">${xacro.error('Unknown finger specifiers: ' + ', '.join(_unknown_finger_tokens_))}</xacro:if>
+	<!-- Handle deprecated lf parameter -->
+	<xacro:property name="lf" default="${None}" />
+	<xacro:if value="${lf is not None}">
+		<!-- If lf was set (i.e. is not None), remove it from fingers if needed -->
+		<xacro:property name="fingers" value="${list(python.set(fingers) - python.set(['lf'] if not lf else []))}" lazy_eval="false" />
+		${xacro.warning('Parameter "lf" is deprecated. Please use fingers="tf ff mf rf" instead!')}
+	</xacro:if>
+	<!-- Unset parameter to indicate that we processed it -->
+	<xacro:property name="lf" remove="true" />
+	<!-- Handle deprecated extra_lite parameter -->
+	<xacro:property name="extra_lite" default="${None}" />
+	<xacro:if value="${extra_lite is not None}">
+		<!-- extra_lite hand doesn't have mf -->
+		<xacro:property name="fingers" value="${list(python.set(fingers) - python.set(['mf'] if extra_lite else []))}" lazy_eval="false" />
+		${xacro.warning('Parameter "extra_lite" is deprecated. Please use fingers="tf ff rf" instead!')}
+	</xacro:if>
+	<!-- Unset parameter to indicate that we processed it -->
+	<xacro:property name="extra_lite" remove="true" />
+</robot>

--- a/sr_description/hand/xacro/process_hand_type_parameter.xacro
+++ b/sr_description/hand/xacro/process_hand_type_parameter.xacro
@@ -1,0 +1,26 @@
+<!-- Map deprecated hand_type values onto new ones -->
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+	<!-- Translate deprecated parameters 'muscle' and 'muscletrans' -->
+	<xacro:if value="${muscle}">
+		<xacro:if value="${muscletrans}">
+			<xacro:property name="hand_type" value="muscletrans" />
+			${xacro.warning('Parameter "muscletrans" is deprecated. Please use hand_type="muscletrans" instead!')}
+		</xacro:if>
+		<xacro:unless value="${muscletrans}">
+			<xacro:property name="hand_type" value="muscle" />
+			${xacro.warning('Parameter "muscle" is deprecated. Please use hand_type="muscle" instead!')}
+		</xacro:unless>
+	</xacro:if>
+	<!-- Unset deprecated parameters, now that we have translated them to hand_type -->
+	<xacro:property name="muscletrans" remove="true" />
+	<xacro:property name="muscle" remove="true" />
+	<!-- Normalize hand_type to be lower case -->
+	<xacro:property name="hand_type" value="${hand_type.lower()}" lazy_eval="false" />
+	<!-- Unify hand_type names, mapping hand_e -> motor, hand_e_plus -> motor+ -->
+	<xacro:if value="${hand_type.lower() == 'hand_e'}">
+		<xacro:property name="hand_type" value="motor" />
+	</xacro:if>
+	<xacro:if value="${hand_type.lower() == 'hand_e_plus'}">
+		<xacro:property name="hand_type" value="motor+" />
+	</xacro:if>
+</robot>

--- a/sr_description/hand/xacro/th_ff_rf_ellipsoid_hand.urdf.xacro
+++ b/sr_description/hand/xacro/th_ff_rf_ellipsoid_hand.urdf.xacro
@@ -16,7 +16,7 @@
     <!-- forward to generic macro -->
     <xacro:include filename="$(find sr_description)/hand/xacro/full_hand.urdf.xacro" />
     <!-- Enforce ellipsoid sensor on First and Ring Finger as well as Thumb -->
-    <xacro:shadowhand fingers="${5 * [1]}" reflect="${reflect}" prefix="${prefix}"
+    <xacro:shadowhand fingers="all" reflect="${reflect}" prefix="${prefix}"
     tip_sensors="${['eli', 'eli', tip_sensors[2], 'eli', tip_sensors[4]]}"/>
   </xacro:macro>
 </robot>

--- a/sr_description/hand/xacro/three_fingers_hand.urdf.xacro
+++ b/sr_description/hand/xacro/three_fingers_hand.urdf.xacro
@@ -11,6 +11,6 @@
     ${xacro.warning("Use full_hand.urdf.xacro instead with fingers='th ff mf'")}
     <!-- forward to generic macro -->
     <xacro:include filename="$(find sr_description)/hand/xacro/full_hand.urdf.xacro" />
-    <xacro:shadowhand fingers="${[1,1,1,0,0]}" reflect="${reflect}" prefix="${prefix}" />
+    <xacro:shadowhand fingers="th ff mf" reflect="${reflect}" prefix="${prefix}" />
   </xacro:macro>
 </robot>

--- a/sr_description/hand/xacro/three_fingers_hand_RF.urdf.xacro
+++ b/sr_description/hand/xacro/three_fingers_hand_RF.urdf.xacro
@@ -11,6 +11,6 @@
     ${xacro.warning("Use full_hand.urdf.xacro instead with fingers='th ff rf'")}
     <!-- forward to generic macro -->
     <xacro:include filename="$(find sr_description)/hand/xacro/full_hand.urdf.xacro" />
-    <xacro:shadowhand fingers="${[1, 1, 0, 1, 0]}" reflect="${reflect}" prefix="${prefix}" />
+    <xacro:shadowhand fingers="th ff rf" reflect="${reflect}" prefix="${prefix}" />
   </xacro:macro>
 </robot>

--- a/sr_description/hand/xacro/thumb/thbase.transmission.xacro
+++ b/sr_description/hand/xacro/thumb/thbase.transmission.xacro
@@ -8,7 +8,7 @@
     <xacro:macro name="thbase_transmission" params="hand_type:=^ prefix:=^">
 
         <!-- muscle hand -->
-        <xacro:if value="${hand_type == 'hand_mt'}">
+        <xacro:if value="${hand_type == 'muscletrans'}">
             <transmission name="${prefix}thbase_transmission">
                 <type>sr_mechanism_model/SimpleTransmissionForMuscle</type>
                 <actuator name="${prefix}THJ5">
@@ -21,7 +21,7 @@
             </transmission>
         </xacro:if>
         <!-- motor hand -->
-        <xacro:unless value="${hand_type == 'hand_mt'}">
+        <xacro:unless value="${hand_type == 'muscletrans'}">
             <transmission name="${prefix}thbase_transmission">
                 <type>sr_mechanism_model/SimpleTransmission</type>
                 <actuator name="${prefix}THJ5">

--- a/sr_description/hand/xacro/thumb/thdistal.transmission.xacro
+++ b/sr_description/hand/xacro/thumb/thdistal.transmission.xacro
@@ -8,7 +8,7 @@
     <xacro:macro name="thdistal_transmission" params="hand_type:=^ prefix:=^">
 
         <!-- muscle hand -->
-        <xacro:if value="${hand_type == 'hand_mt'}">
+        <xacro:if value="${hand_type == 'muscletrans'}">
             <transmission name="${prefix}thdistal_transmission">
                 <type>sr_mechanism_model/SimpleTransmissionForMuscle</type>
                 <actuator name="${prefix}THJ1">
@@ -21,7 +21,7 @@
             </transmission>
         </xacro:if>
         <!-- motor hand -->
-        <xacro:unless value="${hand_type == 'hand_mt'}">
+        <xacro:unless value="${hand_type == 'muscletrans'}">
             <transmission name="${prefix}thdistal_transmission">
                 <type>sr_mechanism_model/SimpleTransmission</type>
                 <actuator name="${prefix}THJ1">

--- a/sr_description/hand/xacro/thumb/thhub.transmission.xacro
+++ b/sr_description/hand/xacro/thumb/thhub.transmission.xacro
@@ -8,7 +8,7 @@
     <xacro:macro name="thhub_transmission" params="hand_type:=^ prefix:=^">
 
         <!-- muscle hand -->
-        <xacro:if value="${hand_type == 'hand_mt'}">
+        <xacro:if value="${hand_type == 'muscletrans'}">
             <transmission name="${prefix}thhub_transmission">
                 <type>sr_mechanism_model/SimpleTransmissionForMuscle</type>
                 <actuator name="${prefix}THJ3">
@@ -21,7 +21,7 @@
             </transmission>
         </xacro:if>
         <!-- motor hand -->
-        <xacro:unless value="${hand_type == 'hand_mt'}">
+        <xacro:unless value="${hand_type == 'muscletrans'}">
             <transmission name="${prefix}thhub_transmission">
                 <type>sr_mechanism_model/SimpleTransmission</type>
                 <actuator name="${prefix}THJ3">

--- a/sr_description/hand/xacro/thumb/thmiddle.transmission.xacro
+++ b/sr_description/hand/xacro/thumb/thmiddle.transmission.xacro
@@ -8,7 +8,7 @@
     <xacro:macro name="thmiddle_transmission" params="hand_type:=^ prefix:=^">
 
         <!-- muscle hand -->
-        <xacro:if value="${hand_type == 'hand_mt'}">
+        <xacro:if value="${hand_type == 'muscletrans'}">
             <transmission name="${prefix}thmiddle_transmission">
                 <type>sr_mechanism_model/SimpleTransmissionForMuscle</type>
                 <actuator name="${prefix}THJ2">
@@ -21,7 +21,7 @@
             </transmission>
         </xacro:if>
         <!-- motor hand -->
-        <xacro:unless value="${hand_type == 'hand_mt'}">
+        <xacro:unless value="${hand_type == 'muscletrans'}">
             <transmission name="${prefix}thmiddle_transmission">
                 <type>sr_mechanism_model/SimpleTransmission</type>
                 <actuator name="${prefix}THJ2">

--- a/sr_description/hand/xacro/thumb/thproximal.transmission.xacro
+++ b/sr_description/hand/xacro/thumb/thproximal.transmission.xacro
@@ -8,7 +8,7 @@
     <xacro:macro name="thproximal_transmission" params="hand_type:=^ prefix:=^">
 
         <!-- muscle hand -->
-        <xacro:if value="${hand_type == 'hand_mt'}">
+        <xacro:if value="${hand_type == 'muscletrans'}">
             <transmission name="${prefix}thproximal_transmission">
                 <type>sr_mechanism_model/SimpleTransmissionForMuscle</type>
                 <actuator name="${prefix}THJ4">
@@ -21,7 +21,7 @@
             </transmission>
         </xacro:if>
         <!-- motor hand -->
-        <xacro:unless value="${hand_type == 'hand_mt'}">
+        <xacro:unless value="${hand_type == 'muscletrans'}">
             <transmission name="${prefix}thproximal_transmission">
                 <type>sr_mechanism_model/SimpleTransmission</type>
                 <actuator name="${prefix}THJ4">

--- a/sr_description/hand/xacro/wrist/wrist.transmission.xacro
+++ b/sr_description/hand/xacro/wrist/wrist.transmission.xacro
@@ -7,7 +7,7 @@
     <!-- prefix can be anything but usually is "r_" or  "l_" for right and left hands distinction -->
     <xacro:macro name="shadowhand_wrist_transmission" params="hand_type:=^ prefix:=^">
         <!-- muscle hand -->
-        <xacro:if value="${hand_type == 'hand_mt'}">
+        <xacro:if value="${hand_type == 'muscletrans'}">
             <transmission name="${prefix}wrist_transmission">
                 <type>sr_mechanism_model/SimpleTransmissionForMuscle</type>
                 <actuator name="${prefix}WRJ2">
@@ -20,7 +20,7 @@
             </transmission>
         </xacro:if>
         <!-- motor hand -->
-        <xacro:unless value="${hand_type == 'hand_mt'}">
+        <xacro:unless value="${hand_type == 'muscletrans'}">
             <transmission name="${prefix}wrist_transmission">
                 <type>sr_mechanism_model/SimpleTransmission</type>
                 <actuator name="${prefix}WRJ2">

--- a/sr_description/robots/arm_and_hand_motor.urdf.xacro
+++ b/sr_description/robots/arm_and_hand_motor.urdf.xacro
@@ -15,5 +15,5 @@
     <child link="rh_forearm" />
     <origin xyz="0 0 0" rpy="0 0 ${2.35619449}" />
   </joint>
-  <xacro:shadowhand hand_type="hand_e" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/arm_and_hand_motor_biotac.urdf.xacro
+++ b/sr_description/robots/arm_and_hand_motor_biotac.urdf.xacro
@@ -15,5 +15,5 @@
     <child link="rh_forearm" />
     <origin xyz="0 0 0" rpy="0 0 ${2.35619449}" />
   </joint>
-  <xacro:shadowhand hand_type="hand_e" tip_sensors="${['bio','bio','bio','bio','bio']}" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor" tip_sensors="${['bio','bio','bio','bio','bio']}" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/arm_and_hand_motor_ellipsoid.urdf.xacro
+++ b/sr_description/robots/arm_and_hand_motor_ellipsoid.urdf.xacro
@@ -15,5 +15,5 @@
     <child link="rh_forearm" />
     <origin xyz="0 0 0" rpy="0 0 ${2.35619449}" />
   </joint>
-  <xacro:shadowhand hand_type="hand_e" tip_sensors="${['eli','eli','eli','eli','eli']}" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor" tip_sensors="${['eli','eli','eli','eli','eli']}" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/arm_and_hand_motor_three_finger.urdf.xacro
+++ b/sr_description/robots/arm_and_hand_motor_three_finger.urdf.xacro
@@ -15,5 +15,5 @@
     <child link="rh_forearm" />
     <origin xyz="0 0 0" rpy="0 0 ${2.35619449}" />
   </joint>
-  <xacro:shadowhand hand_type="hand_e" fingers="${[1,1,1,0,0]}"  reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor" fingers="${[1,1,1,0,0]}" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/arm_and_hand_motor_three_finger.urdf.xacro
+++ b/sr_description/robots/arm_and_hand_motor_three_finger.urdf.xacro
@@ -15,5 +15,5 @@
     <child link="rh_forearm" />
     <origin xyz="0 0 0" rpy="0 0 ${2.35619449}" />
   </joint>
-  <xacro:shadowhand hand_type="motor" fingers="${[1,1,1,0,0]}" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor" fingers="th ff mf" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/arm_and_hand_muscle.urdf.xacro
+++ b/sr_description/robots/arm_and_hand_muscle.urdf.xacro
@@ -15,5 +15,5 @@
     <child link="rh_forearm" />
     <origin xyz="0 0 0" rpy="0 0 ${pi}" />
   </joint>
-  <xacro:shadowhand hand_type="hand_m" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="muscle" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/arm_and_hand_muscle_biotac.urdf.xacro
+++ b/sr_description/robots/arm_and_hand_muscle_biotac.urdf.xacro
@@ -15,5 +15,5 @@
     <child link="rh_forearm" />
     <origin xyz="0 0 0" rpy="0 0 ${pi}" />
   </joint>
-  <xacro:shadowhand hand_type="hand_m" tip_sensors="${['bio','bio','bio','bio','bio']}" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="muscle" tip_sensors="${['bio','bio','bio','bio','bio']}" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/bimanual_shadowhand_extra_lite.urdf.xacro
+++ b/sr_description/robots/bimanual_shadowhand_extra_lite.urdf.xacro
@@ -11,11 +11,11 @@ name="bimanual_shadowhand_motor">
     <child link="rh_forearm" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="motor" fingers="${[1,1,0,1]}" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor" fingers="th ff rf" reflect="1.0" prefix="rh_" />
   <joint name="right_hand_to_left_hand" type="fixed">
     <parent link="rh_forearm" />
     <child link="lh_forearm" />
     <origin xyz="$(arg arm_x_separation) 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="motor" fingers="${[1,1,0,1]}" reflect="-1.0" prefix="lh_" />
+  <xacro:shadowhand hand_type="motor" fingers="th ff rf" reflect="-1.0" prefix="lh_" />
 </robot>

--- a/sr_description/robots/bimanual_shadowhand_extra_lite.urdf.xacro
+++ b/sr_description/robots/bimanual_shadowhand_extra_lite.urdf.xacro
@@ -11,11 +11,11 @@ name="bimanual_shadowhand_motor">
     <child link="rh_forearm" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="hand_e" fingers="${[1,1,0,1]}" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor" fingers="${[1,1,0,1]}" reflect="1.0" prefix="rh_" />
   <joint name="right_hand_to_left_hand" type="fixed">
     <parent link="rh_forearm" />
     <child link="lh_forearm" />
     <origin xyz="$(arg arm_x_separation) 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="hand_e" fingers="${[1,1,0,1]}" reflect="-1.0" prefix="lh_" />
+  <xacro:shadowhand hand_type="motor" fingers="${[1,1,0,1]}" reflect="-1.0" prefix="lh_" />
 </robot>

--- a/sr_description/robots/bimanual_shadowhand_lite.urdf.xacro
+++ b/sr_description/robots/bimanual_shadowhand_lite.urdf.xacro
@@ -11,11 +11,11 @@ name="bimanual_shadowhand_motor">
     <child link="rh_forearm" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="hand_e" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor" reflect="1.0" prefix="rh_" />
   <joint name="right_hand_to_left_hand" type="fixed">
     <parent link="rh_forearm" />
     <child link="lh_forearm" />
     <origin xyz="$(arg arm_x_separation) 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="hand_e" reflect="-1.0" prefix="lh_" />
+  <xacro:shadowhand hand_type="motor" reflect="-1.0" prefix="lh_" />
 </robot>

--- a/sr_description/robots/bimanual_shadowhand_lite_btsp.urdf.xacro
+++ b/sr_description/robots/bimanual_shadowhand_lite_btsp.urdf.xacro
@@ -11,11 +11,11 @@ name="bimanual_shadowhand_motor">
     <child link="rh_forearm" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="hand_e" tip_sensors="${5 * ['bt_sp']}" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor" tip_sensors="${5 * ['bt_sp']}" reflect="1.0" prefix="rh_" />
   <joint name="right_hand_to_left_hand" type="fixed">
     <parent link="rh_forearm" />
     <child link="lh_forearm" />
     <origin xyz="$(arg arm_x_separation) 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="hand_e" tip_sensors="${5 * ['bt_sp']}" reflect="-1.0" prefix="lh_" />
+  <xacro:shadowhand hand_type="motor" tip_sensors="${5 * ['bt_sp']}" reflect="-1.0" prefix="lh_" />
 </robot>

--- a/sr_description/robots/bimanual_shadowhand_lite_right_btsp.urdf.xacro
+++ b/sr_description/robots/bimanual_shadowhand_lite_right_btsp.urdf.xacro
@@ -11,11 +11,11 @@ name="bimanual_shadowhand_motor">
     <child link="rh_forearm" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="hand_e" tip_sensors="${['bt_sp','bt_sp','bt_sp','bt_sp','bt_sp']}" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor" tip_sensors="${['bt_sp','bt_sp','bt_sp','bt_sp','bt_sp']}" reflect="1.0" prefix="rh_" />
   <joint name="right_hand_to_left_hand" type="fixed">
     <parent link="rh_forearm" />
     <child link="lh_forearm" />
     <origin xyz="$(arg arm_x_separation) 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="hand_e" reflect="-1.0" prefix="lh_" />
+  <xacro:shadowhand hand_type="motor" reflect="-1.0" prefix="lh_" />
 </robot>

--- a/sr_description/robots/bimanual_shadowhand_motor.urdf.xacro
+++ b/sr_description/robots/bimanual_shadowhand_motor.urdf.xacro
@@ -9,12 +9,12 @@ name="bimanual_shadowhand_motor">
     <child link="rh_forearm" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="hand_e" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor" reflect="1.0" prefix="rh_" />
   <joint name="right_hand_to_left_hand" type="fixed">
     <parent link="rh_forearm" />
     <child link="lh_forearm" />
     <origin xyz="0.4 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="hand_e" reflect="-1.0" prefix="lh_" />
+  <xacro:shadowhand hand_type="motor" reflect="-1.0" prefix="lh_" />
 
 </robot>

--- a/sr_description/robots/bimanual_shadowhand_motor_plus.urdf.xacro
+++ b/sr_description/robots/bimanual_shadowhand_motor_plus.urdf.xacro
@@ -11,11 +11,11 @@ name="bimanual_shadowhand_motor">
     <child link="rh_forearm" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="hand_e_plus" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor+" reflect="1.0" prefix="rh_" />
   <joint name="right_hand_to_left_hand" type="fixed">
     <parent link="rh_forearm" />
     <child link="lh_forearm" />
     <origin xyz="$(arg arm_x_separation) 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="hand_e_plus" reflect="-1.0" prefix="lh_" />
+  <xacro:shadowhand hand_type="motor+" reflect="-1.0" prefix="lh_" />
 </robot>

--- a/sr_description/robots/bimanual_shadowhand_motor_plus_right_biotac.urdf.xacro
+++ b/sr_description/robots/bimanual_shadowhand_motor_plus_right_biotac.urdf.xacro
@@ -9,12 +9,12 @@ name="bimanual_shadowhand_motor">
     <child link="rh_forearm" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="hand_e_plus" tip_sensors="${['bt_sp','bt_sp','bt_sp','bt_sp','bt_sp']}" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor+" tip_sensors="${['bt_sp','bt_sp','bt_sp','bt_sp','bt_sp']}" reflect="1.0" prefix="rh_" />
   <joint name="right_hand_to_left_hand" type="fixed">
     <parent link="rh_forearm" />
     <child link="lh_forearm" />
     <origin xyz="0.4 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="hand_e_plus" reflect="-1.0" prefix="lh_" />
+  <xacro:shadowhand hand_type="motor+" reflect="-1.0" prefix="lh_" />
 
 </robot>

--- a/sr_description/robots/desk_arm_and_hand_motor.urdf.xacro
+++ b/sr_description/robots/desk_arm_and_hand_motor.urdf.xacro
@@ -18,5 +18,5 @@
     <limit lower="0" upper="0" effort="10" velocity="1.0" />
     <dynamics damping="3.5" />
   </joint>
-  <xacro:shadowhand hand_type="hand_e" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/shadowhand_edc_muscle.urdf.xacro
+++ b/sr_description/robots/shadowhand_edc_muscle.urdf.xacro
@@ -13,7 +13,7 @@ name="shadowhand_muscle">
     <child link="rh_forearm_disk" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="hand_mt" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="muscletrans" reflect="1.0" prefix="rh_" />
   <link name="rh_forearm_disk">
     <inertial>
       <origin xyz="0 0 0" />

--- a/sr_description/robots/shadowhand_edc_muscle_biotac.urdf.xacro
+++ b/sr_description/robots/shadowhand_edc_muscle_biotac.urdf.xacro
@@ -16,7 +16,7 @@ name="shadowhand_motor">
   <!-- C6 hand with BioTAC sensor
   (C) 2012 fnh, hendrich@informatik.uni-hamburg.de
 -->
-  <xacro:shadowhand hand_type="hand_mt" tip_sensors="${['bio','bio','bio','bio','bio']}" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="muscletrans" tip_sensors="${['bio','bio','bio','bio','bio']}" reflect="1.0" prefix="rh_" />
   <link name="rh_forearm_disk">
     <inertial>
       <origin xyz="0 0 0" />

--- a/sr_description/robots/shadowhand_extra_lite.urdf.xacro
+++ b/sr_description/robots/shadowhand_extra_lite.urdf.xacro
@@ -13,5 +13,5 @@ name="shadowhand_motor">
     <child link="rh_forearm" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="hand_e" fingers="${[1,1,0,1]}" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor" fingers="${[1,1,0,1]}" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/shadowhand_extra_lite.urdf.xacro
+++ b/sr_description/robots/shadowhand_extra_lite.urdf.xacro
@@ -13,5 +13,5 @@ name="shadowhand_motor">
     <child link="rh_forearm" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="motor" fingers="${[1,1,0,1]}" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor" fingers="th ff rf" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/shadowhand_left_edc_muscle.urdf.xacro
+++ b/sr_description/robots/shadowhand_left_edc_muscle.urdf.xacro
@@ -13,7 +13,7 @@ name="shadowhand_muscle">
     <child link="lh_forearm_disk" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="hand_mt" reflect="-1.0" prefix="lh_" />
+  <xacro:shadowhand hand_type="muscletrans" reflect="-1.0" prefix="lh_" />
   <link name="lh_forearm_disk">
     <inertial>
       <origin xyz="0 0 0" />

--- a/sr_description/robots/shadowhand_left_extra_lite.urdf.xacro
+++ b/sr_description/robots/shadowhand_left_extra_lite.urdf.xacro
@@ -13,5 +13,5 @@ name="shadowhand_motor">
     <child link="lh_forearm" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="motor" fingers="${[1,1,0,1]}" reflect="-1.0" prefix="lh_" />
+  <xacro:shadowhand hand_type="motor" fingers="th ff rf" reflect="-1.0" prefix="lh_" />
 </robot>

--- a/sr_description/robots/shadowhand_left_extra_lite.urdf.xacro
+++ b/sr_description/robots/shadowhand_left_extra_lite.urdf.xacro
@@ -13,5 +13,5 @@ name="shadowhand_motor">
     <child link="lh_forearm" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="hand_e" fingers="${[1,1,0,1]}" reflect="-1.0" prefix="lh_" />
+  <xacro:shadowhand hand_type="motor" fingers="${[1,1,0,1]}" reflect="-1.0" prefix="lh_" />
 </robot>

--- a/sr_description/robots/shadowhand_left_lite.urdf.xacro
+++ b/sr_description/robots/shadowhand_left_lite.urdf.xacro
@@ -13,5 +13,5 @@ name="shadowhand_motor">
     <child link="lh_forearm" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="hand_e" reflect="-1.0" prefix="lh_" />
+  <xacro:shadowhand hand_type="motor" reflect="-1.0" prefix="lh_" />
 </robot>

--- a/sr_description/robots/shadowhand_left_lite_btsp.urdf.xacro
+++ b/sr_description/robots/shadowhand_left_lite_btsp.urdf.xacro
@@ -13,5 +13,5 @@ name="shadowhand_motor">
     <child link="lh_forearm" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="hand_e" tip_sensors="${['bt_sp','bt_sp','bt_sp','bt_sp']}" reflect="-1.0" prefix="lh_" />
+  <xacro:shadowhand hand_type="motor" tip_sensors="${['bt_sp','bt_sp','bt_sp','bt_sp']}" reflect="-1.0" prefix="lh_" />
 </robot>

--- a/sr_description/robots/shadowhand_left_motor.urdf.xacro
+++ b/sr_description/robots/shadowhand_left_motor.urdf.xacro
@@ -13,5 +13,5 @@ name="shadowhand_motor">
     <child link="lh_forearm" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="hand_e" reflect="-1.0" prefix="lh_" />
+  <xacro:shadowhand hand_type="motor" reflect="-1.0" prefix="lh_" />
 </robot>

--- a/sr_description/robots/shadowhand_left_motor_biotac.urdf.xacro
+++ b/sr_description/robots/shadowhand_left_motor_biotac.urdf.xacro
@@ -13,5 +13,5 @@ name="shadowhand_motor">
     <child link="lh_forearm" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="hand_e" tip_sensors="${['bio','bio','bio','bio','bio']}" reflect="-1.0" prefix="lh_" />
+  <xacro:shadowhand hand_type="motor" tip_sensors="${['bio','bio','bio','bio','bio']}" reflect="-1.0" prefix="lh_" />
 </robot>

--- a/sr_description/robots/shadowhand_left_motor_plus.urdf.xacro
+++ b/sr_description/robots/shadowhand_left_motor_plus.urdf.xacro
@@ -13,5 +13,5 @@
       <child link="lh_forearm" />
       <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
     </joint>
-    <xacro:shadowhand hand_type="hand_e_plus" reflect="-1.0" prefix="lh_" />
+  <xacro:shadowhand hand_type="motor+" reflect="-1.0" prefix="lh_" />
 </robot>

--- a/sr_description/robots/shadowhand_left_motor_plus_btsp.urdf.xacro
+++ b/sr_description/robots/shadowhand_left_motor_plus_btsp.urdf.xacro
@@ -13,5 +13,5 @@
       <child link="lh_forearm" />
       <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
     </joint>
-    <xacro:shadowhand hand_type="hand_e_plus" tip_sensors="${['bt_sp','bt_sp','bt_sp','bt_sp','bt_sp']}" reflect="-1.0" prefix="lh_" />
+  <xacro:shadowhand hand_type="motor+" tip_sensors="${['bt_sp','bt_sp','bt_sp','bt_sp','bt_sp']}" reflect="-1.0" prefix="lh_" />
 </robot>

--- a/sr_description/robots/shadowhand_left_muscle.urdf.xacro
+++ b/sr_description/robots/shadowhand_left_muscle.urdf.xacro
@@ -13,7 +13,7 @@ name="shadowhand_muscle">
     <child link="lh_forearm_disk" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="hand_m" reflect="-1.0" prefix="lh_" />
+  <xacro:shadowhand hand_type="muscle" reflect="-1.0" prefix="lh_" />
   <link name="lh_forearm_disk">
     <inertial>
       <origin xyz="0 0 0" />

--- a/sr_description/robots/shadowhand_lite.urdf.xacro
+++ b/sr_description/robots/shadowhand_lite.urdf.xacro
@@ -13,5 +13,5 @@ name="shadowhand_motor">
     <child link="rh_forearm" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="hand_e" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/shadowhand_lite_btsp.urdf.xacro
+++ b/sr_description/robots/shadowhand_lite_btsp.urdf.xacro
@@ -13,5 +13,5 @@ name="shadowhand_motor">
     <child link="rh_forearm" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="hand_e" tip_sensors="${['bt_sp','bt_sp','bt_sp','bt_sp']}" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor" tip_sensors="${['bt_sp','bt_sp','bt_sp','bt_sp']}" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/shadowhand_motor.urdf.xacro
+++ b/sr_description/robots/shadowhand_motor.urdf.xacro
@@ -13,5 +13,5 @@
       <child link="rh_forearm" />
       <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
     </joint>
-    <xacro:shadowhand hand_type="hand_e" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/shadowhand_motor_biotac.urdf.xacro
+++ b/sr_description/robots/shadowhand_motor_biotac.urdf.xacro
@@ -16,5 +16,5 @@ name="shadowhand_motor">
   <!-- C6 hand with BioTAC sensor
   (C) 2012 fnh, hendrich@informatik.uni-hamburg.de
 -->
-  <xacro:shadowhand hand_type="hand_e" tip_sensors="${['bio','bio','bio','bio','bio']}" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor" tip_sensors="${['bio','bio','bio','bio','bio']}" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/shadowhand_motor_btsp.urdf.xacro
+++ b/sr_description/robots/shadowhand_motor_btsp.urdf.xacro
@@ -13,5 +13,5 @@ name="shadowhand_motor">
     <child link="rh_forearm" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="hand_e" tip_sensors="${['bt_sp','bt_sp','bt_sp','bt_sp','bt_sp']}" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor" tip_sensors="${['bt_sp','bt_sp','bt_sp','bt_sp','bt_sp']}" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/shadowhand_motor_ellipsoid.urdf.xacro
+++ b/sr_description/robots/shadowhand_motor_ellipsoid.urdf.xacro
@@ -13,5 +13,5 @@ name="shadowhand_motor">
     <child link="rh_forearm" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="hand_e" tip_sensors="${['eli','eli','eli','eli','eli']}" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor" tip_sensors="${['eli','eli','eli','eli','eli']}" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/shadowhand_motor_ff_biotac.urdf.xacro
+++ b/sr_description/robots/shadowhand_motor_ff_biotac.urdf.xacro
@@ -13,5 +13,5 @@
       <child link="rh_forearm" />
       <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
     </joint>
-    <xacro:shadowhand hand_type="hand_e" tip_sensors="${['std','bio','std','std','std']}" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor" tip_sensors="${['std','bio','std','std','std']}" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/shadowhand_motor_no_lf.urdf.xacro
+++ b/sr_description/robots/shadowhand_motor_no_lf.urdf.xacro
@@ -13,5 +13,5 @@
       <child link="rh_forearm" />
       <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
     </joint>
-  <xacro:shadowhand hand_type="motor" fingers="${[1,1,1,1,0]}" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor" fingers="th ff mf rf" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/shadowhand_motor_no_lf.urdf.xacro
+++ b/sr_description/robots/shadowhand_motor_no_lf.urdf.xacro
@@ -13,5 +13,5 @@
       <child link="rh_forearm" />
       <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
     </joint>
-    <xacro:shadowhand hand_type="hand_e" fingers="${[1,1,1,1,0]}" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor" fingers="${[1,1,1,1,0]}" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/shadowhand_motor_no_mf_rf_lf.urdf.xacro
+++ b/sr_description/robots/shadowhand_motor_no_mf_rf_lf.urdf.xacro
@@ -13,5 +13,5 @@
       <child link="rh_forearm" />
       <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
     </joint>
-  <xacro:shadowhand hand_type="motor" fingers="${[1,1,0,0,0]}" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor" fingers="th ff" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/shadowhand_motor_no_mf_rf_lf.urdf.xacro
+++ b/sr_description/robots/shadowhand_motor_no_mf_rf_lf.urdf.xacro
@@ -13,5 +13,5 @@
       <child link="rh_forearm" />
       <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
     </joint>
-    <xacro:shadowhand hand_type="hand_e" fingers="${[1,1,0,0,0]}" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor" fingers="${[1,1,0,0,0]}" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/shadowhand_motor_plus.urdf.xacro
+++ b/sr_description/robots/shadowhand_motor_plus.urdf.xacro
@@ -13,5 +13,5 @@
       <child link="rh_forearm" />
       <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
     </joint>
-    <xacro:shadowhand hand_type="hand_e_plus" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor+" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/shadowhand_motor_plus_biotac.urdf.xacro
+++ b/sr_description/robots/shadowhand_motor_plus_biotac.urdf.xacro
@@ -13,5 +13,5 @@
       <child link="rh_forearm" />
       <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
     </joint>
-    <xacro:shadowhand hand_type="hand_e_plus" tip_sensors="${['bio','bio','bio','bio','bio']}" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor+" tip_sensors="${['bio','bio','bio','bio','bio']}" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/shadowhand_motor_plus_btsp.urdf.xacro
+++ b/sr_description/robots/shadowhand_motor_plus_btsp.urdf.xacro
@@ -13,5 +13,5 @@
       <child link="rh_forearm" />
       <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
     </joint>
-    <xacro:shadowhand hand_type="hand_e_plus" tip_sensors="${['bt_sp','bt_sp','bt_sp','bt_sp','bt_sp']}" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor+" tip_sensors="${['bt_sp','bt_sp','bt_sp','bt_sp','bt_sp']}" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/shadowhand_motor_th_ff_rf_ellipsoid.urdf.xacro
+++ b/sr_description/robots/shadowhand_motor_th_ff_rf_ellipsoid.urdf.xacro
@@ -13,5 +13,5 @@ name="shadowhand_motor">
     <child link="rh_forearm" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="hand_e" tip_sensors="${['eli','eli','std','eli','std']}" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor" tip_sensors="${['eli','eli','std','eli','std']}" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/shadowhand_muscle.urdf.xacro
+++ b/sr_description/robots/shadowhand_muscle.urdf.xacro
@@ -13,7 +13,7 @@ name="shadowhand_muscle">
     <child link="rh_forearm_disk" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="hand_m" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="muscle" reflect="1.0" prefix="rh_" />
   <link name="rh_forearm_disk">
     <inertial>
       <origin xyz="0 0 0" />

--- a/sr_description/robots/shadowhand_muscle_biotac.urdf.xacro
+++ b/sr_description/robots/shadowhand_muscle_biotac.urdf.xacro
@@ -17,7 +17,7 @@ name="shadowhand_motor">
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
 
-  <xacro:shadowhand hand_type="hand_m" tip_sensors="${['bio','bio','bio','bio','bio']}" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="muscle" tip_sensors="${['bio','bio','bio','bio','bio']}" reflect="1.0" prefix="rh_" />
   <link name="rh_forearm_disk">
     <inertial>
       <origin xyz="0 0 0" />

--- a/sr_description/robots/sr_three_finger_edc_muscle_biotac.urdf.xacro
+++ b/sr_description/robots/sr_three_finger_edc_muscle_biotac.urdf.xacro
@@ -13,5 +13,5 @@ name="shadowhand_motor">
     <child link="rh_forearm" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="hand_mt" fingers="${[1,1,1,0,0]}" tip_sensors="${['bio','bio','bio','std','std']}" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="muscletrans" fingers="${[1,1,1,0,0]}" tip_sensors="${['bio','bio','bio','std','std']}" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/sr_three_finger_edc_muscle_biotac.urdf.xacro
+++ b/sr_description/robots/sr_three_finger_edc_muscle_biotac.urdf.xacro
@@ -13,5 +13,5 @@ name="shadowhand_motor">
     <child link="rh_forearm" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="muscletrans" fingers="${[1,1,1,0,0]}" tip_sensors="${['bio','bio','bio','std','std']}" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="muscletrans" fingers="th ff mf" tip_sensors="${['bio','bio','bio','std','std']}" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/sr_three_finger_motor.urdf.xacro
+++ b/sr_description/robots/sr_three_finger_motor.urdf.xacro
@@ -13,5 +13,5 @@ name="shadowhand_motor">
     <child link="rh_forearm" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="motor" fingers="${[1,1,1,0,0]}" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor" fingers="th ff mf" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/sr_three_finger_motor.urdf.xacro
+++ b/sr_description/robots/sr_three_finger_motor.urdf.xacro
@@ -13,5 +13,5 @@ name="shadowhand_motor">
     <child link="rh_forearm" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="hand_e" fingers="${[1,1,1,0,0]}" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor" fingers="${[1,1,1,0,0]}" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/sr_three_finger_rf_motor.urdf.xacro
+++ b/sr_description/robots/sr_three_finger_rf_motor.urdf.xacro
@@ -13,5 +13,5 @@ name="shadowhand_motor">
     <child link="rh_forearm" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="motor" fingers="${[1,1,0,1,0]}" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor" fingers="th ff rf" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/robots/sr_three_finger_rf_motor.urdf.xacro
+++ b/sr_description/robots/sr_three_finger_rf_motor.urdf.xacro
@@ -13,5 +13,5 @@ name="shadowhand_motor">
     <child link="rh_forearm" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>
-  <xacro:shadowhand hand_type="hand_e" fingers="${[1,1,0,1,0]}" reflect="1.0" prefix="rh_" />
+  <xacro:shadowhand hand_type="motor" fingers="${[1,1,0,1,0]}" reflect="1.0" prefix="rh_" />
 </robot>

--- a/sr_description/test/test_process_fingers_parameter.xacro
+++ b/sr_description/test/test_process_fingers_parameter.xacro
@@ -1,0 +1,21 @@
+<test xmlns:xacro="http://www.ros.org/wiki/xacro">
+	<xacro:property name="_all_finger_tokens_" value="${python.set('th ff mf rf lf'.split())}" />
+	<xacro:macro name="test" params="msg:='' fingers:=all lf:=${None} extra_lite:=${None}">
+		<xacro:property name="input" value="${fingers}" lazy_eval="false" />
+		<xacro:include filename="$(find sr_description)/hand/xacro/process_fingers_parameter.xacro" />
+	${input} ${msg} : ${fingers}
+	</xacro:macro>
+	<xacro:test />
+	<xacro:test fingers="FF RF lF"/>
+	<xacro:test msg="lf=false" fingers="FF RF lF" lf="false"/>
+	<xacro:test msg="lf=false" lf="false" />
+	<xacro:test msg="lf=true" lf="true" />
+	<!-- Use non-default set of finger tokens -->
+	<xacro:property name="_all_finger_tokens_" value="${python.set('a b c'.split())}" />
+	<xacro:test msg="_all_finger_tokens_='a b c'" />
+	<!-- lite hand finger tokens -->
+	<xacro:property name="_all_finger_tokens_" value="${python.set('th ff mf rf'.split())}" />
+	<xacro:test msg="lite" />
+	<xacro:test msg="lite extra_lite=true" extra_lite="true" />
+	<xacro:test msg="lite extra_lite=false" extra_lite="false" />
+</test>


### PR DESCRIPTION
This PR proposes:
1. More readable hand types:
   - hand_e -> motor
   - hand_e_plus -> motor+
   - hand_m -> muscle
   - hand_mt -> muscletrans
2. A simplified `fingers` specification:
   - `fingers=all` (for a fully-fingered hand)
   - `fingers='th, mf, rf'` (textual list, acceptable separaters could be spaces, commas, and semicolons)
3. Support all types of tactile sensor specifications:
     - [x] plaing string: `tip_sensors=bio` (same sensor for all fingers)
     - [x] list-like: `tip_sensors='bio, bio, std, std, none'` (assuming order th ff mf rf lf)
     - [x] dict-like: `tip_sensors='th=bio, ff=bio, mf=std, rf=std, lf=none'`

See individual commit messages for details.
This PR requires the latest `xacro` melodic or noetic branch from [our fork](https://github.com/ubi-agni/xacro). 
I will trigger a release asap - if there are no issues running our xacro code.

### TODO
- [ ] Validate xacro extension on our xacro code base
- [x] Fix corner cases failing when `running test/test_compatibility.py`